### PR TITLE
Standardize Names

### DIFF
--- a/PyAres/Analyzing/__init__.py
+++ b/PyAres/Analyzing/__init__.py
@@ -1,8 +1,8 @@
 from .analysis_service import AresAnalyzerService
-from .analyzer_models import Analysis, AnalysisRequest, InfoResponse
+from .analyzer_models import AnalysisResponse, AnalysisRequest, InfoResponse
 
 __all__ = [
-    "Analysis",
+    "AnalysisResponse",
     "AnalysisRequest",
     "InfoResponse",
     "AresAnalyzerService",

--- a/PyAres/Analyzing/analysis_service.py
+++ b/PyAres/Analyzing/analysis_service.py
@@ -23,10 +23,10 @@ from ..Utils import ares_outcome_utils
 # Import python models
 from ..Models import ares_data_models, RequestMetadata
 from ..Models import AresSchemaEntry
-from .analyzer_models import AnalysisRequest, Analysis, InfoResponse
+from .analyzer_models import AnalysisRequest, AnalysisResponse, InfoResponse
 
 # Type hints for the user's custom logic
-AnalyzeLogicFunction = Callable[[AnalysisRequest], Union[Analysis, Awaitable[Analysis]]]
+AnalyzeLogicFunction = Callable[[AnalysisRequest], Union[AnalysisResponse, Awaitable[AnalysisResponse]]]
 
 class AresAnalyzerServiceWrapper(analyzer_service_grpc.AresRemoteAnalyzerServiceServicer):
     """
@@ -73,7 +73,7 @@ class AresAnalyzerServiceWrapper(analyzer_service_grpc.AresRemoteAnalyzerService
             if isinstance(python_response, Awaitable):
                 python_response = python_response.__await__()
 
-            if not isinstance(python_response, Analysis):
+            if not isinstance(python_response, AnalysisResponse):
                 print("Analysis response was an invalid type, ")
                 proto_analysis.analysis_outcome = ares_outcome_enum_pb2.FAILURE
                 proto_analysis.error_string = "The user's custom analysis logic returned an invalid type, analysis cannot be processed"

--- a/PyAres/Analyzing/analyzer_models.py
+++ b/PyAres/Analyzing/analyzer_models.py
@@ -20,7 +20,7 @@ class AnalysisRequest:
     def __repr__(self) -> str:
         return self.__str__()
 
-class Analysis:
+class AnalysisResponse:
     """ Represents the result of an analysis process. """
 
     def __init__(self, result: float, outcome: Outcome = Outcome.SUCCESS, error_string: str = ""):

--- a/PyAres/Demo/analyzer_test.py
+++ b/PyAres/Demo/analyzer_test.py
@@ -1,6 +1,6 @@
-from PyAres import AresAnalyzerService, AnalysisRequest, Analysis, AresDataType, Outcome
+from PyAres import AresAnalyzerService, AnalysisRequest, AnalysisResponse, AresDataType, Outcome
 
-def analyze(request: AnalysisRequest) -> Analysis:
+def analyze(request: AnalysisRequest) -> AnalysisResponse:
     #Custom Analysis Logic
     temperature = request.inputs.get("Temperature")
 
@@ -10,7 +10,7 @@ def analyze(request: AnalysisRequest) -> Analysis:
 
     print(f"Temperature: {temperature}")
 
-    analysis = Analysis(result=temperature)
+    analysis = AnalysisResponse(result=temperature)
     return analysis
 
 

--- a/PyAres/Demo/analyzer_wiki.py
+++ b/PyAres/Demo/analyzer_wiki.py
@@ -1,12 +1,12 @@
-from PyAres import AresAnalyzerService, AnalysisRequest, Analysis, AresDataType, Outcome
+from PyAres import AresAnalyzerService, AnalysisRequest, AnalysisResponse, AresDataType, Outcome
 
-def analyze_sample(request: AnalysisRequest) -> Analysis:
+def analyze_sample(request: AnalysisRequest) -> AnalysisResponse:
     # 1. Extract inputs
     # 'Growth_Metric' would come from a sensor or previous step
     raw_value = request.inputs.get("Growth_Metric")
 
     if raw_value is None:
-        return Analysis(result=0.0, outcome=Outcome.FAILURE)
+        return AnalysisResponse(result=0.0, outcome=Outcome.FAILURE)
     
     # 2. Perform Logic
     print(f"Analyzing sample with value: {raw_value}")
@@ -15,7 +15,7 @@ def analyze_sample(request: AnalysisRequest) -> Analysis:
     is_success = calculated_score > 10.0 # Define success criteria
     
     # 3. Return Result
-    return Analysis(result=calculated_score, outcome=Outcome.SUCCESS)
+    return AnalysisResponse(result=calculated_score, outcome=Outcome.SUCCESS)
 
 if __name__ == "__main__":
     service = AresAnalyzerService(

--- a/PyAres/Planning/planner_models.py
+++ b/PyAres/Planning/planner_models.py
@@ -166,7 +166,7 @@ class PlanResponse:
                  parameter_names: Optional[list[str]] = None,
                  parameter_values: Optional[list] = None,
                  parameter_data: Optional[dict[str,Any]] = None,
-                 planning_outcome: Outcome = Outcome.SUCCESS, 
+                 outcome: Outcome = Outcome.SUCCESS, 
                  error_string: str = ""):
         """
         Initializes a PlanResponse. Using either lists of names and values or a python dictonary of name:value pairs
@@ -189,7 +189,7 @@ class PlanResponse:
         else:
              raise ValueError("No values to assign!")
         
-        self.outcome = planning_outcome
+        self.outcome = outcome
         self.error_string = error_string
     
     def __str__(self):

--- a/PyAres/__init__.py
+++ b/PyAres/__init__.py
@@ -4,7 +4,7 @@ from .Planning import PlanRequest
 from .Planning import PlanningParameter
 from .Planning import ParameterHistoryItem
 from .Analyzing import AresAnalyzerService
-from .Analyzing import Analysis
+from .Analyzing import AnalysisResponse
 from .Analyzing import AnalysisRequest
 from .Analyzing import InfoResponse
 from .Device import AresDeviceService

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Analyzers can be initialized using the AresAnalyzerService class. Below is a bas
 ```Python
 from PyAres import AresAnalyzerService
 from PyAres import AnalysisRequest
-from PyAres import Analysis
+from PyAres import AnalysisResponse
 from PyAres import AresDataType
 
-def analyze(request: AnalysisRequest) -> Analysis:
+def analyze(request: AnalysisRequest) -> AnalysisResponse:
     #Custom Analysis Logic
     growth = request.inputs.get("Growth")
     temperature = request.inputs.get("Temperature")
@@ -70,7 +70,7 @@ def analyze(request: AnalysisRequest) -> Analysis:
     print(f"Growth: {growth}")
     print(f"Temperature: {temperature}")
 
-    analysis = Analysis(result=growth, success=True)
+    analysis = AnalysisResponse(result=growth, success=True)
     return analysis
 
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,7 +1,7 @@
 import unittest
 from PyAres import AresAnalyzerService, Outcome
 from PyAres.Models import ares_data_models
-from PyAres.Analyzing.analyzer_models import AnalysisRequest, Analysis
+from PyAres.Analyzing.analyzer_models import AnalysisRequest, AnalysisResponse
 from ares_datamodel.analyzing.remote import ares_remote_analyzer_service_pb2 as analyzer_service
 from ares_datamodel.analyzing import analysis_pb2
 from ares_datamodel import ares_data_type_pb2, ares_outcome_enum_pb2, ares_data_schema_pb2
@@ -28,11 +28,11 @@ class TestAresAnalyzerService(unittest.TestCase):
     def setUp(self):
         self.captured_request: AnalysisRequest | None = None
 
-        def dummy_analyze(request: AnalysisRequest) -> Analysis:
+        def dummy_analyze(request: AnalysisRequest) -> AnalysisResponse:
             self.captured_request = request
             
             # Return a valid Analysis object
-            return Analysis(
+            return AnalysisResponse(
                 result=100.0,
                 outcome=Outcome.SUCCESS
             )


### PR DESCRIPTION
This pull request is designed to fix a few names in the PyAres library to be more standardized. Changes analyzers so that they return an AnalysisResponse instead of an Analysis, and planners now have an "Outcome" rather than a "Planning Outcome".